### PR TITLE
Add support for Blender 2.80 and later using the same method as mmd_tools

### DIFF
--- a/mmd_tools_helper/.gitignore
+++ b/mmd_tools_helper/.gitignore
@@ -1,0 +1,132 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# VSCode
+.vscode/

--- a/mmd_tools_helper/__init__.py
+++ b/mmd_tools_helper/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
 	"name": "MMD tools helper",
 	"author": "Hogarth-MMD",
 	"version": (2, 4),
-	"blender": (2, 79, 0),
+	"blender": (2, 80, 0),
 	"location": "View3D > Tool Shelf > MMD Tools Helper",
 	"description": "various mmd_tools helper scripts",
 	"warning": "",
@@ -10,65 +10,97 @@ bl_info = {
 	"category": "Object",
 	}
 
-import bpy
+__bl_classes = []
+def register_wrap(cls):
+    #print('%3d'%len(__bl_classes), cls)
+    #assert(cls not in __bl_classes)
+    if __make_annotations:
+        bl_props = {k:v for k, v in cls.__dict__.items() if isinstance(v, __bpy_property)}
+        if bl_props:
+            if '__annotations__' not in cls.__dict__:
+                setattr(cls, '__annotations__', {})
+            annotations = cls.__dict__['__annotations__']
+            for k, v in bl_props.items():
+                #print('   -', k, v)
+                #assert(v.__class__.__name__ == '_PropertyDeferred' or getattr(v[0], '__module__', None) == 'bpy.props' and isinstance(v[1], dict))
+                annotations[k] = v
+                delattr(cls, k)
+    if hasattr(cls, 'bl_rna'):
+        __bl_classes.append(cls)
+    return cls
 
+if "bpy" in locals():
+    if bpy.app.version < (2, 71, 0):
+        import imp as importlib
+    else:
+        import importlib
+    importlib.reload(model)
+    importlib.reload(mmd_view)
+    importlib.reload(mmd_lamp_setup)
+    importlib.reload(convert_to_blender_camera)
+    importlib.reload(background_color_picker)
+    importlib.reload(boneMaps_renamer)
+    importlib.reload(replace_bones_renaming)
+    importlib.reload(armature_diagnostic)
+    importlib.reload(add_foot_leg_ik)
+    importlib.reload(add_hand_arm_ik)
+    importlib.reload(display_panel_groups)
+    importlib.reload(toon_textures_to_node_editor_shader)
+    importlib.reload(toon_modifier)
+    importlib.reload(reverse_japanese_english)
+    importlib.reload(miscellaneous_tools)
+    importlib.reload(blender_bone_names_to_japanese_bone_names)
+else:
+    import bpy
+    import logging
+
+    __make_annotations = (bpy.app.version >= (2, 80, 0))
+    __bpy_property = (bpy.props._PropertyDeferred if hasattr(bpy.props, '_PropertyDeferred') else tuple)
+    from . import model
+    from . import mmd_view
+    from . import mmd_lamp_setup
+    from . import convert_to_blender_camera
+    from . import background_color_picker
+    from . import boneMaps_renamer
+    from . import replace_bones_renaming
+    from . import armature_diagnostic
+    from . import add_foot_leg_ik
+    from . import add_hand_arm_ik
+    from . import display_panel_groups
+    from . import toon_textures_to_node_editor_shader
+    from . import toon_modifier
+    from . import reverse_japanese_english
+    from . import miscellaneous_tools
+    from . import blender_bone_names_to_japanese_bone_names
+
+if bpy.app.version < (2, 80, 0):
+    bl_info['blender'] = (2, 70, 0)
+
+logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+
+@register_wrap
 class MMDToolsHelperPanel(bpy.types.Panel):
 	"""Creates the MMD Tools Helper Panel in a VIEW_3D TOOLS tab"""
 	bl_label = "MMD Tools Helper"
 	bl_idname = "OBJECT_PT_mmd_tools_helper"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
 		layout = self.layout
 		row = layout.row()
 
-from . import model
-from . import mmd_view
-from . import mmd_lamp_setup
-from . import convert_to_blender_camera
-from . import background_color_picker
-from . import boneMaps_renamer
-from . import replace_bones_renaming
-from . import armature_diagnostic
-from . import add_foot_leg_ik
-from . import add_hand_arm_ik
-from . import display_panel_groups
-from . import toon_textures_to_node_editor_shader
-from . import toon_modifier
-from . import reverse_japanese_english
-from . import miscellaneous_tools
-from . import blender_bone_names_to_japanese_bone_names
-
-
-import imp
-imp.reload(model)
-imp.reload(mmd_view)
-imp.reload(mmd_lamp_setup)
-imp.reload(convert_to_blender_camera)
-imp.reload(background_color_picker)
-imp.reload(boneMaps_renamer)
-imp.reload(replace_bones_renaming)
-imp.reload(armature_diagnostic)
-imp.reload(add_foot_leg_ik)
-imp.reload(add_hand_arm_ik)
-imp.reload(display_panel_groups)
-imp.reload(toon_textures_to_node_editor_shader)
-imp.reload(toon_modifier)
-imp.reload(reverse_japanese_english)
-imp.reload(miscellaneous_tools)
-imp.reload(blender_bone_names_to_japanese_bone_names)
-
-
 
 def register():
-	bpy.utils.register_module(__name__)
-
+    for cls in __bl_classes:
+        bpy.utils.register_class(cls)
+    print(__name__, 'registed %d classes'%len(__bl_classes))
 
 def unregister():
-	bpy.utils.unregister_module(__name__)
+    for cls in reversed(__bl_classes):
+        bpy.utils.unregister_class(cls)
 
 
 if __name__ == "__main__":
-	register()
+    register()

--- a/mmd_tools_helper/add_foot_leg_ik.py
+++ b/mmd_tools_helper/add_foot_leg_ik.py
@@ -1,5 +1,7 @@
 import bpy
 import math
+
+from . import register_wrap
 from . import model
 
 # def armature_diagnostic():
@@ -32,12 +34,13 @@ from . import model
 		# if b in bpy.context.active_object.data.bones.keys():
 			# print('This armature appears to already have IK bones. This bone seems to be an IK bone:', '\n', b)
 
+@register_wrap
 class Add_MMD_foot_leg_IK_Panel(bpy.types.Panel):
 	"""Add foot and leg IK bones and constraints to MMD model"""
 	bl_idname = "OBJECT_PT_mmd_add_foot_leg_ik"
 	bl_label = "Add foot leg IK to MMD model"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
@@ -372,7 +375,7 @@ def main(context):
 
 	bpy.context.active_object.data.draw_type = 'OCTAHEDRAL'
 
-
+@register_wrap
 class Add_MMD_foot_leg_IK(bpy.types.Operator):
 	"""Add foot and leg IK bones and constraints to MMD model"""
 	bl_idname = "object.add_foot_leg_ik"
@@ -386,16 +389,3 @@ class Add_MMD_foot_leg_IK(bpy.types.Operator):
 		clear_IK(context)
 		main(context)
 		return {'FINISHED'}
-
-def register():
-	bpy.utils.register_class(Add_MMD_foot_leg_IK)
-	bpy.utils.register_class(Add_MMD_foot_leg_IK_Panel)
-
-
-def unregister():
-	bpy.utils.unregister_class(Add_MMD_foot_leg_IK)
-	bpy.utils.unregister_class(Add_MMD_foot_leg_IK_Panel)
-
-
-if __name__ == "__main__":
-	register()

--- a/mmd_tools_helper/add_hand_arm_ik.py
+++ b/mmd_tools_helper/add_hand_arm_ik.py
@@ -1,13 +1,16 @@
 import bpy
 import math
+
+from . import register_wrap
 from . import model
 
+@register_wrap
 class Add_MMD_Hand_Arm_IK_Panel(bpy.types.Panel):
 	"""Add hand and arm IK bones and constraints to active MMD model"""
 	bl_idname = "OBJECT_PT_mmd_add_hand_arm_ik"
 	bl_label = "Add Hand Arm IK to MMD model"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
@@ -294,7 +297,7 @@ def main(context):
 	bpy.context.active_object.pose.bones["middle1_IK_R_t"].bone_group = bpy.context.active_object.pose.bone_groups['IK']
 
 
-
+@register_wrap
 class Add_MMD_Hand_Arm_IK(bpy.types.Operator):
 	"""Add hand and arm IK bones and constraints to active MMD model"""
 	bl_idname = "object.add_hand_arm_ik"
@@ -308,16 +311,3 @@ class Add_MMD_Hand_Arm_IK(bpy.types.Operator):
 		clear_IK(context)
 		main(context)
 		return {'FINISHED'}
-
-def register():
-	bpy.utils.register_class(Add_MMD_Hand_Arm_IK)
-	bpy.utils.register_class(Add_MMD_Hand_Arm_IK_Panel)
-
-
-def unregister():
-	bpy.utils.unregister_class(Add_MMD_Hand_Arm_IK)
-	bpy.utils.unregister_class(Add_MMD_Hand_Arm_IK_Panel)
-
-
-if __name__ == "__main__":
-	register()

--- a/mmd_tools_helper/armature_diagnostic.py
+++ b/mmd_tools_helper/armature_diagnostic.py
@@ -1,14 +1,16 @@
 import bpy
+
+from . import register_wrap
 from . import import_csv
 from . import model
 
-
+@register_wrap
 class ArmatureDiagnosticPanel(bpy.types.Panel):
 	"""Armature Diagnostic panel"""
 	bl_label = "Armature Diagnostic Panel"
 	bl_idname = "OBJECT_PT_armature_diagnostic"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
@@ -51,7 +53,7 @@ def main(context):
 		print("Please note that these 3 bones are MMD semi-standard bones and are not essential in an MMD armature:")
 		print("upper body 2, thumb0_L, thumb0_R")
 
-
+@register_wrap
 class ArmatureDiagnostic(bpy.types.Operator):
 	"""Tooltip"""
 	bl_idname = "mmd_tools_helper.armature_diagnostic"
@@ -72,23 +74,3 @@ class ArmatureDiagnostic(bpy.types.Operator):
 		print()
 		main(context)
 		return {'FINISHED'}
-
-
-
-def register():
-	bpy.utils.register_class(ArmatureDiagnosticPanel)
-	bpy.utils.register_class(ArmatureDiagnostic)
-
-
-def unregister():
-	bpy.utils.unregister_class(ArmatureDiagnosticPanel)
-	bpy.utils.unregister_class(ArmatureDiagnostic)
-
-
-
-if __name__ == "__main__":
-	register()
-
-
-
-	

--- a/mmd_tools_helper/background_color_picker.py
+++ b/mmd_tools_helper/background_color_picker.py
@@ -1,12 +1,15 @@
 import bpy
 import sys
 
+from . import register_wrap
+
+@register_wrap
 class MMDBackgroundColorPicker_Panel(bpy.types.Panel):
 	"""Selects world background color and a contrasting text color"""
 	bl_idname = "OBJECT_PT_mmd_background_color_picker"
 	bl_label = "MMD background color picker"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
@@ -31,6 +34,7 @@ def main(context):
 
 	bpy.context.user_preferences.themes[0].view_3d.space.text_hi = (round(1-bpy.context.scene.BackgroundColor[0]), round(1-bpy.context.scene.BackgroundColor[1]),round(1-bpy.context.scene.BackgroundColor[2]))
 
+@register_wrap
 class MMDBackgroundColorPicker(bpy.types.Operator):
 	"""Selects world background color and a contrasting text color"""
 	bl_idname = "mmd_tools_helper.background_color_picker"
@@ -42,17 +46,3 @@ class MMDBackgroundColorPicker(bpy.types.Operator):
 	def execute(self, context):
 		main(context)
 		return {'FINISHED'}
-
-
-def register():
-	bpy.utils.register_class(MMDBackgroundColorPicker)
-	bpy.utils.register_class(MMDBackgroundColorPicker_Panel)
-
-
-def unregister():
-	bpy.utils.unregister_class(MMDBackgroundColorPicker)
-	bpy.utils.register_class(MMDBackgroundColorPicker_Panel)
-
-
-if __name__ == "__main__":
-	register()

--- a/mmd_tools_helper/blender_bone_names_to_japanese_bone_names.py
+++ b/mmd_tools_helper/blender_bone_names_to_japanese_bone_names.py
@@ -1,12 +1,15 @@
 import bpy
+
+from . import register_wrap
 from . import model
 
+@register_wrap
 class BlenderToJapaneseBoneNamesPanel(bpy.types.Panel):
 	"""Creates a Panel"""
 	bl_idname = "OBJECT_PT_blender_to_japanese_bone_names"
 	bl_label = "Copy Blender bone names to Japanese bone names"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
@@ -25,7 +28,7 @@ def main(context):
 			armature.pose.bones[b.name].mmd_bone.name_j = b.name
 
 
-
+@register_wrap
 class BlenderToJapaneseBoneNames(bpy.types.Operator):
 	"""Copy Blender bone names to Japanese bone names"""
 	bl_idname = "mmd_tools_helper.blender_to_japanese_bone_names"
@@ -34,16 +37,3 @@ class BlenderToJapaneseBoneNames(bpy.types.Operator):
 	def execute(self, context):
 		main(context)
 		return {'FINISHED'}
-
-def register():
-	bpy.utils.register_class(BlenderToJapaneseBoneNames)
-	bpy.utils.register_class(BlenderToJapaneseBoneNamesPanel)
-
-
-def unregister():
-	bpy.utils.unregister_class(BlenderToJapaneseBoneNames)
-	bpy.utils.unregister_class(BlenderToJapaneseBoneNamesPanel)
-
-
-if __name__ == "__main__":
-	register()

--- a/mmd_tools_helper/boneMaps_renamer.py
+++ b/mmd_tools_helper/boneMaps_renamer.py
@@ -1,15 +1,18 @@
 
 
 import bpy
+
+from . import register_wrap
 from . import model
 from . import import_csv
 
+@register_wrap
 class BonesRenamerPanel_MTH(bpy.types.Panel):
 	"""Creates the Bones Renamer Panel in a VIEW_3D TOOLS tab"""
 	bl_label = "Bones Renamer"
 	bl_idname = "OBJECT_PT_bones_renamer_MTH"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
@@ -117,6 +120,7 @@ def main(context):
 	bpy.ops.pose.select_all(action='SELECT')
 
 
+@register_wrap
 class BonesRenamer(bpy.types.Operator):
 	"""Mass bones renamer for armature conversion"""
 	bl_idname = "object.bones_renamer"
@@ -135,17 +139,3 @@ class BonesRenamer(bpy.types.Operator):
 	def execute(self, context):
 		main(context)
 		return {'FINISHED'}
-
-
-def register():
-	bpy.utils.register_class(BonesRenamer)
-	bpy.utils.register_class(BonesRenamerPanel_MTH)
-
-
-def unregister():
-	bpy.utils.unregister_class(BonesRenamer)
-	bpy.utils.unregister_class(BonesRenamerPanel_MTH)
-
-
-if __name__ == "__main__":
-	register()

--- a/mmd_tools_helper/convert_to_blender_camera.py
+++ b/mmd_tools_helper/convert_to_blender_camera.py
@@ -1,11 +1,14 @@
 import bpy
 
+from . import register_wrap
+
+@register_wrap
 class MMDCameraToBlenderCameraPanel(bpy.types.Panel):
 	"""Convert MMD cameras back to Blender cameras"""
 	bl_idname = "OBJECT_PT_mmd_camera_to_blender_camera"
 	bl_label = "Convert MMD Cameras to Blender cameras"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
@@ -39,6 +42,7 @@ def main(context):
 			bpy.context.scene.objects.unlink(camera.parent)
 			bpy.ops.object.parent_clear(type='CLEAR_KEEP_TRANSFORM')
 
+@register_wrap
 class MMDCameraToBlenderCamera(bpy.types.Operator):
 	"""Convert MMD cameras back to Blender cameras"""
 	bl_idname = "mmd_tools_helper.mmd_camera_to_blender_camera"
@@ -51,17 +55,3 @@ class MMDCameraToBlenderCamera(bpy.types.Operator):
 	def execute(self, context):
 		main(context)
 		return {'FINISHED'}
-
-
-def register():
-	bpy.utils.register_class(MDCameraToBlenderCamera)
-	bpy.utils.register_class(MMDCameraToBlenderCameraPanel)
-
-
-def unregister():
-	bpy.utils.unregister_class(MDCameraToBlenderCamera)
-	bpy.utils.unregister_class(MMDCameraToBlenderCameraPanel)
-
-
-if __name__ == "__main__":
-	register()

--- a/mmd_tools_helper/display_panel_groups.py
+++ b/mmd_tools_helper/display_panel_groups.py
@@ -1,16 +1,19 @@
 import bpy
+
+from . import register_wrap
 from . import model
 from . import import_csv
 
 def __items(display_item_frame):
     return getattr(display_item_frame, 'data', display_item_frame.items)
 
+@register_wrap
 class MmdToolsDisplayPanelGroupsPanel(bpy.types.Panel):
 	"""Mass add bone names and shape key names to display panel groups"""
 	bl_idname = "OBJECT_PT_mmd_add_display_panel_groups"
 	bl_label = "Create Display Panel Groups and Add Items"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
@@ -239,6 +242,7 @@ def main(context):
 		display_panel_groups_non_vertex_morphs(root)
 		delete_empty_display_panel_groups(root)
 
+@register_wrap
 class MmdToolsDisplayPanelGroups(bpy.types.Operator):
 	"""Mass add bone names and shape key names to display panel groups"""
 	bl_idname = "object.add_display_panel_groups"
@@ -253,16 +257,3 @@ class MmdToolsDisplayPanelGroups(bpy.types.Operator):
 	def execute(self, context):
 		main(context)
 		return {'FINISHED'}
-
-def register():
-	bpy.utils.register_class(MmdToolsDisplayPanelGroups)
-	bpy.utils.register_class(MmdToolsDisplayPanelGroupsPanel)
-
-
-def unregister():
-	bpy.utils.unregister_class(MmdToolsDisplayPanelGroups)
-	bpy.utils.unregister_class(MmdToolsDisplayPanelGroupsPanel)
-
-
-if __name__ == "__main__":
-	register()

--- a/mmd_tools_helper/miscellaneous_tools.py
+++ b/mmd_tools_helper/miscellaneous_tools.py
@@ -1,13 +1,15 @@
 import bpy
+
+from . import register_wrap
 from . import model
 
-
+@register_wrap
 class MiscellaneousToolsPanel(bpy.types.Panel):
 	"""Miscellaneous Tools panel"""
 	bl_label = "Miscellaneous Tools Panel"
 	bl_idname = "OBJECT_PT_miscellaneous_tools"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
@@ -191,7 +193,7 @@ def main(context):
 		correct_root_center()
 
 
-
+@register_wrap
 class MiscellaneousTools(bpy.types.Operator):
 	"""Miscellanous Tools"""
 	bl_idname = "mmd_tools_helper.miscellaneous_tools"
@@ -206,21 +208,3 @@ class MiscellaneousTools(bpy.types.Operator):
 	def execute(self, context):
 		main(context)
 		return {'FINISHED'}
-
-
-def register():
-	bpy.utils.register_class(MiscellaneousToolsPanel)
-	bpy.utils.register_class(MiscellaneousTools)
-
-
-def unregister():
-	bpy.utils.unregister_class(MiscellaneousToolsPanel)
-	bpy.utils.unregister_class(MiscellaneousTools)
-
-
-if __name__ == "__main__":
-	register()
-
-
-
-	

--- a/mmd_tools_helper/mmd_lamp_setup.py
+++ b/mmd_tools_helper/mmd_lamp_setup.py
@@ -1,18 +1,21 @@
 import bpy
 
+from . import register_wrap
+
+@register_wrap
 class MMDLampSetupPanel(bpy.types.Panel):
 	"""One-click Lamp Setup for mmd_tools"""
 	bl_idname = "OBJECT_PT_mmd_lamp_setup"
 	bl_label = "MMD Lamp Setup"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
 		layout = self.layout
 		row = layout.row()
 
-		row.label(text="MMD Lamp", icon="LAMP")
+		row.label(text="MMD Lamp", icon="LAMP" if bpy.app.version < (2,80,0) else "LIGHT")
 		row = layout.row()
 		row.operator("mmd_tools_helper.mmd_lamp_setup", text = "MMD Lamp")
 		row = layout.row()
@@ -76,6 +79,7 @@ def main(context):
 				# o.data.use_auto_clip_end = True
 				# o.data.shadow_color = (0, 0, 0)
 
+@register_wrap
 class MMDLampSetup(bpy.types.Operator):
 	"""One-click Lamp Setup for mmd_tools"""
 	bl_idname = "mmd_tools_helper.mmd_lamp_setup"
@@ -88,18 +92,3 @@ class MMDLampSetup(bpy.types.Operator):
 	def execute(self, context):
 		main(context)
 		return {'FINISHED'}
-
-
-def register():
-	bpy.utils.register_class(MMDLampSetup)
-	bpy.utils.register_class(MMDLampSetupPanel)
-
-
-def unregister():
-	bpy.utils.unregister_class(MMDLampSetup)
-	bpy.utils.unregister_class(MMDLampSetupPanel)
-
-
-if __name__ == "__main__":
-	register()
-

--- a/mmd_tools_helper/mmd_view.py
+++ b/mmd_tools_helper/mmd_view.py
@@ -3,12 +3,15 @@
 import bpy
 import math
 
+from . import register_wrap
+
+@register_wrap
 class MMDViewPanel(bpy.types.Panel):
 	"""Camera and Grid to be same as MikuMikuDance"""
 	bl_idname = "OBJECT_PT_mmd_view"
 	bl_label = "MMD View"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
@@ -85,7 +88,7 @@ def main(context):
 
 
 
-
+@register_wrap
 class MMDView(bpy.types.Operator):
 	"""Camera and Grid to be same as MikuMikuDance"""
 	bl_idname = "mmd_tools_helper.mmd_view"
@@ -98,17 +101,3 @@ class MMDView(bpy.types.Operator):
 	def execute(self, context):
 		main(context)
 		return {'FINISHED'}
-
-
-def register():
-	bpy.utils.register_class(MMDView)
-	bpy.utils.register_class(MMDViewPanel)
-
-
-def unregister():
-	bpy.utils.unregister_class(MMDView)
-	bpy.utils.unregister_class(MMDViewPanel)
-
-
-if __name__ == "__main__":
-	register()

--- a/mmd_tools_helper/replace_bones_renaming.py
+++ b/mmd_tools_helper/replace_bones_renaming.py
@@ -1,29 +1,32 @@
 
 import bpy
+
+from . import register_wrap
 from . import model
 
+@register_wrap
 class ReplaceBonesRenamingPanel(bpy.types.Panel):
 	"""Replace Bones Renaming panel"""
 	bl_label = "Replace bones renaming panel"
 	bl_idname = "OBJECT_PT_replace_bones_renaming"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
 		layout = self.layout
 		row = layout.row()
-		row.label("Find this string in bone names:")
+		row.label(text="Find this string in bone names:")
 		row = layout.row()
 		row.prop(context.scene,"find_bone_string")
 		row = layout.row()
-		row.label("Replace it with this string:")
+		row.label(text="Replace it with this string:")
 		row = layout.row()
 		row.prop(context.scene,"replace_bone_string")
 		row = layout.row()
 		row.prop(context.scene, "bones_all_or_selected")
 		row = layout.row()
-		row.label("Selected bones only")
+		row.label(text="Selected bones only")
 		row = layout.row()
 		row.operator("mmd_tools_helper.replace_bones_renaming", text = "Find and replace a string in bone names")
 		row = layout.row()
@@ -41,6 +44,7 @@ def main(context):
 				b.name = b.name.replace(bpy.context.scene.find_bone_string, bpy.context.scene.replace_bone_string)
 
 
+@register_wrap
 class ReplaceBonesRenaming(bpy.types.Operator):
 	"""Find and replace mass renaming of bones"""
 	bl_idname = "mmd_tools_helper.replace_bones_renaming"
@@ -59,19 +63,3 @@ class ReplaceBonesRenaming(bpy.types.Operator):
 	def execute(self, context):
 		main(context)
 		return {'FINISHED'}
-
-
-
-def register():
-	bpy.utils.register_class(ReplaceBonesRenamingPanel)
-	bpy.utils.register_class(ReplaceBonesRenaming)
-
-
-def unregister():
-	bpy.utils.unregister_class(ReplaceBonesRenamingPanel)
-	bpy.utils.unregister_class(ReplaceBonesRenaming)
-
-
-
-if __name__ == "__main__":
-	register()

--- a/mmd_tools_helper/reverse_japanese_english.py
+++ b/mmd_tools_helper/reverse_japanese_english.py
@@ -1,11 +1,14 @@
 import bpy
 
+from . import register_wrap
+
+@register_wrap
 class ReverseJapaneseEnglishPanel(bpy.types.Panel):
 	"""Sets up nodes in Blender node editor for rendering toon textures"""
 	bl_idname = "OBJECT_PT_reverse_japanese_english"
 	bl_label = "Reverse Japanese English names"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
@@ -55,6 +58,7 @@ def main(context):
 					vm.name_e = name_j
 
 
+@register_wrap
 class ReverseJapaneseEnglish(bpy.types.Operator):
 	"""Reverses Japanese and English names of shape keys, materials, bones"""
 	bl_idname = "mmd_tools_helper.reverse_japanese_english"
@@ -63,16 +67,3 @@ class ReverseJapaneseEnglish(bpy.types.Operator):
 	def execute(self, context):
 		main(context)
 		return {'FINISHED'}
-
-def register():
-	bpy.utils.register_class(ReverseJapaneseEnglish)
-	bpy.utils.register_class(ReverseJapaneseEnglishPanel)
-
-
-def unregister():
-	bpy.utils.unregister_class(ReverseJapaneseEnglishShader)
-	bpy.utils.unregister_class(ReverseJapaneseEnglishShaderPanel)
-
-
-if __name__ == "__main__":
-	register()

--- a/mmd_tools_helper/toon_modifier.py
+++ b/mmd_tools_helper/toon_modifier.py
@@ -1,15 +1,18 @@
 import bpy
+
+from . import register_wrap
 from . import model
 
  # blend_type
 	# Type:	enum in ["MIX", "ADD", "MULTIPLY", "SUBTRACT", "SCREEN", "DIVIDE", "DIFFERENCE", "DARKEN", "LIGHTEN", "OVERLAY", "DODGE", "BURN", "HUE", "SATURATION", "VALUE", "COLOR", "SOFT_LIGHT", "LINEAR_LIGHT"], default ‘MIX’
 
+@register_wrap
 class MMDToonModifierPanel(bpy.types.Panel):
 	"""User can modify the rendering of toon texture color"""
 	bl_idname = "OBJECT_PT_mmd_toon_modifier"
 	bl_label = "MMD toon modifier"
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
@@ -38,7 +41,7 @@ def main(context):
 					n.blend_type = bpy.context.scene.ToonModifierBlendType
 
 
-
+@register_wrap
 class MMDToonModifier(bpy.types.Operator):
 	"""User can modify the rendering of toon texture color"""
 	bl_idname = "mmd_tools_helper.toon_modifier"
@@ -55,17 +58,3 @@ class MMDToonModifier(bpy.types.Operator):
 	def execute(self, context):
 		main(context)
 		return {'FINISHED'}
-
-
-def register():
-	bpy.utils.register_class(MMDToonModifier)
-	bpy.utils.register_class(MMDToonModifierPanel)
-
-
-def unregister():
-	bpy.utils.unregister_class(MMDToonModifier)
-	bpy.utils.unregister_class(MMDToonModifierPanel)
-
-
-if __name__ == "__main__":
-	register()

--- a/mmd_tools_helper/toon_textures_to_node_editor_shader.py
+++ b/mmd_tools_helper/toon_textures_to_node_editor_shader.py
@@ -1,4 +1,6 @@
 import bpy
+
+from . import register_wrap
 from . import model
 
 
@@ -6,12 +8,13 @@ from . import model
 # So the length of the list of pixels is 4 X number of pixels
 # pixels are in left-to-right rows from bottom left to top right of image
 
+@register_wrap
 class MMDToonTexturesToNodeEditorShaderPanel(bpy.types.Panel):
 	"""Sets up nodes in Blender node editor for rendering toon textures"""
 	bl_idname = "OBJECT_PT_mmd_toon_render_node_editor"
 	bl_label = "MMD toon textures render using node editor "
 	bl_space_type = "VIEW_3D"
-	bl_region_type = "TOOLS"
+	bl_region_type = "TOOLS" if bpy.app.version < (2,80,0) else "UI"
 	bl_category = "mmd_tools_helper"
 
 	def draw(self, context):
@@ -251,7 +254,7 @@ def main(context):
 
 
 
-
+@register_wrap
 class MMDToonTexturesToNodeEditorShader(bpy.types.Operator):
 	"""Sets up nodes in Blender node editor for rendering toon textures"""
 	bl_idname = "mmd_tools_helper.mmd_toon_render_node_editor"
@@ -272,19 +275,3 @@ class MMDToonTexturesToNodeEditorShader(bpy.types.Operator):
 			# create_default_material_nodes(context)
 			main(context)
 		return {'FINISHED'}
-
-
-def register():
-	bpy.utils.register_class(MMDToonTexturesToNodeEditorShader)
-	bpy.utils.register_class(MMDToonTexturesToNodeEditorShaderPanel)
-
-
-def unregister():
-	bpy.utils.unregister_class(MMDToonTexturesToNodeEditorShader)
-	bpy.utils.unregister_class(MMDToonTexturesToNodeEditorShaderPanel)
-
-
-if __name__ == "__main__":
-	register()
-
-


### PR DESCRIPTION
I have tested that the panel shows up in Blender 2.93.

![image](https://user-images.githubusercontent.com/70152495/130336097-982b29c5-76a2-4066-b1a4-da311b1d482d.png)

### Caution
I haven't tested the functionality, because I don't know the add-on functions.
I haven't tested with Blender 2.79, because I don't have it.